### PR TITLE
Fix compilation with StrictNullChecks and make the properties have more sense

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -27,7 +27,7 @@ export interface User {
 	mfa_enabled: boolean; // if multi factor authentication is enabled
 	created_at: Date; // registration date
 	verified: boolean; // if the user is offically verified
-	email: string; // email of the user
+	email: string | null; // email of the user
 	flags: bigint; // UserFlags
 	public_flags: bigint;
 	user_settings: UserSettings;

--- a/src/util/Config.ts
+++ b/src/util/Config.ts
@@ -13,7 +13,7 @@ interface Options<T> {
 
 type Deserialize<T> = (text: string) => T;
 
-function getConfigPath(name: string, configFileName: string, extension: string): string {
+export function getConfigPathForFile(name: string, configFileName: string, extension: string): string {
 	const configEnvPath = envPaths(name, { suffix: "" }).config;
 	const configPath = path.resolve(configEnvPath, `${configFileName}${extension}`)
 	return configPath


### PR DESCRIPTION
1. The first thing this does, is to allow phone to either be a string or be null, instead of being able to be undefined, this terms mean different things and shouldn't be used interchangeably.
2. This changes the way emails are handled, every Discord account needs an email, so this can't be undefined or NULL, as we would be having a wrong formatted database/request
3. Avatar can't be undefined, as it can either be a string, to the corresponding image, or NULL, if NULL no avatar should be displayed. 

This pull request was made by me and @luth31 to better adapt to typescript principles, have better request formatting, and to support the update on the gateway to the new config schemas, as this new ones required this checks to be enabled in order to pass all the formatting and validation tests.