### PR TITLE
Add regions to Config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@fosscord/server-util",
-	"version": "1.3.34",
+	"version": "1.3.35",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fosscord/server-util",
-			"version": "1.3.34",
+			"version": "1.3.35",
 			"license": "GPLV3",
 			"dependencies": {
 				"@types/jsonwebtoken": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fosscord/server-util",
-	"version": "1.3.34",
+	"version": "1.3.35",
 	"description": "Utility functions for the all server repositories",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/util/Config.ts
+++ b/src/util/Config.ts
@@ -24,6 +24,15 @@ export interface RateLimitOptions {
 	timespan: number;
 }
 
+export interface Region {
+	id: string,
+	name: string,
+	vip: boolean,
+	custom: boolean,
+	deprecated: boolean,
+	optimal: boolean,
+}
+
 export interface DefaultOptions {
 	gateway: {
 		endpoint: string | null;
@@ -116,6 +125,10 @@ export interface DefaultOptions {
 			minSymbols: number;
 		};
 	};
+	regions: {
+		default: string;
+		available: Region[];
+	}
 }
 
 export const DefaultOptions: DefaultOptions = {
@@ -206,6 +219,12 @@ export const DefaultOptions: DefaultOptions = {
 			minUpperCase: 2,
 			minSymbols: 0,
 		},
+	},
+	regions: {
+		default: "fosscord",
+		available: [ 
+			{ id: "fosscord", name: "Fosscord", vip: false, custom: false, deprecated: false, optimal: false },
+		]
 	},
 };
 


### PR DESCRIPTION
Allow instance owners to define available Guild regions and a default region for new Guilds